### PR TITLE
📝 Fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,11 +897,11 @@ Also see GitLab Contributors: [https://gitlab.com/galtzo-floss/flag_shih_tzu/-/g
 <details markdown="1">
  <summary>⭐️ Star History</summary>
 
-<a href="https://star-history.com/galtzo-floss/flag_shih_tzu&Date">
+<a href="https://star-history.dera.page/galtzo-floss/flag_shih_tzu&Date">
  <picture>
- <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=galtzo-floss/flag_shih_tzu&type=Date&theme=dark" />
- <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=galtzo-floss/flag_shih_tzu&type=Date" />
- <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=galtzo-floss/flag_shih_tzu&type=Date" />
+ <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=galtzo-floss/flag_shih_tzu&type=Date&theme=dark" />
+ <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=galtzo-floss/flag_shih_tzu&type=Date" />
+ <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=galtzo-floss/flag_shih_tzu&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The old provider requires API tokens now, but this fork revives the original service